### PR TITLE
Fix test failures

### DIFF
--- a/request.go
+++ b/request.go
@@ -558,6 +558,9 @@ func handlePointer(attribute interface{}, args []string, fieldType reflect.Type,
 	case map[string]interface{}:
 		var err error
 		concreteVal, err = handleStruct(attribute, args, fieldType, fieldValue)
+		if err != nil {
+			return reflect.Value{}, ErrUnsupportedPtrType(reflect.ValueOf(attribute), fieldType, structField)
+		}
 		return concreteVal.Elem(), err
 	default:
 		return reflect.Value{}, ErrUnsupportedPtrType(reflect.ValueOf(attribute), fieldType, structField)


### PR DESCRIPTION
This should fix the test failures on https://github.com/google/jsonapi/pull/99

Before:

```
$ go test ./...
--- FAIL: TestUnmarshalToStructWithPointerAttr_BadType_MapPtr (0.00s)
	request_test.go:154: Unexpected error message: json: cannot unmarshal object into Go value of type string
--- FAIL: TestUnmarshalToStructWithPointerAttr_BadType_Struct (0.00s)
	request_test.go:172: Unexpected error message: json: cannot unmarshal object into Go value of type string
FAIL
FAIL	_/Users/abramowi/dev/git-repos/jsonapi	3.823s
ok  	_/Users/abramowi/dev/git-repos/jsonapi/examples	0.012s
```

After:

```
$ go test ./...
ok  	_/Users/abramowi/dev/git-repos/jsonapi	4.026s
ok  	_/Users/abramowi/dev/git-repos/jsonapi/examples	0.015s
```